### PR TITLE
added mc-router will route based on domain name

### DIFF
--- a/mc-router.yaml
+++ b/mc-router.yaml
@@ -1,0 +1,79 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mc-router
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: services-watcher
+rules:
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["watch","list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: mc-router-services-watcher
+subjects:
+- kind: ServiceAccount
+  name: mc-router
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: services-watcher
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mc-router
+spec:
+  type: NodePort
+  ports:
+  - targetPort: web
+    name: web
+    port: 8080
+    nodePort: 30580
+  - targetPort: proxy
+    name: proxy
+    port: 25565
+    nodePort: 30565
+  selector:
+    run: mc-router
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    run: mc-router
+  name: mc-router
+spec:
+  selector:
+    matchLabels:
+      run: mc-router
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        run: mc-router
+    spec:
+      serviceAccountName: mc-router
+      containers:
+      - image: itzg/mc-router:latest
+        name: mc-router
+        args: ["--api-binding", ":8080", "--in-kube-cluster"]
+        ports:
+        - name: proxy
+          containerPort: 25565
+        - name: web
+          containerPort: 8080
+        resources:
+          requests:
+            memory: 50Mi
+            cpu: "100m"
+          limits:
+            memory: 100Mi
+            cpu: "250m"

--- a/vanilla.yaml
+++ b/vanilla.yaml
@@ -4,6 +4,8 @@ metadata:
   name: mc-vanilla
   labels:
     app: mc-vanilla
+  annotations:
+    "mc-router.itzg.me/externalServerName": "oasis.learn.study"
 spec:
   ports:
   - port: 25565


### PR DESCRIPTION
To test this add a line to your `/etc/hosts` file:
```
<ip of server> oasis.learn.study
```
and replace `<ip of server>` with the ip of the server then connect with the minecraft client to oasis.learn.study it will then route the request to mc-vanilla as that has the annotation on it. To be sure that it works that way have a log open `kubectl logs <mc-router-#hash>`